### PR TITLE
Add inspect linkages test

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,6 +33,8 @@ test:
         - nitime.fmri
         - nitime.fmri.tests
         - nitime.tests
+    commands:
+        - conda inspect linkages -n _test nitime  # [linux]
 
 about:
     home: http://nipy.org/nitime


### PR DESCRIPTION
Ideally we should always run this test when there is a `cython` extension.
